### PR TITLE
⚡ Bolt: Optimize HomeScreen Rebuilds During Scrolling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Avoiding setState in Scroll Listeners
+**Learning:** Calling `setState` inside a `ScrollController` listener causes the entire widget tree to rebuild on every frame during scrolling, leading to severe performance bottlenecks and UI jank.
+**Action:** Use `AnimatedBuilder` attached directly to the `ScrollController` (or `PageController`) to listen for scroll changes, and pass the static parts of the UI as the `child` parameter. This confines rebuilds only to the specific widgets that depend on the scroll offset.

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,10 +9,10 @@ import 'routine_screen.dart';
 class _DesktopDragScrollBehavior extends MaterialScrollBehavior {
   @override
   Set<PointerDeviceKind> get dragDevices => {
-        PointerDeviceKind.touch,
-        PointerDeviceKind.mouse,
-        PointerDeviceKind.stylus,
-      };
+    PointerDeviceKind.touch,
+    PointerDeviceKind.mouse,
+    PointerDeviceKind.stylus,
+  };
 }
 
 class HomeScreen extends StatefulWidget {
@@ -34,7 +34,6 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
-  double _pageValue = 0.0;
 
   // Morning palette
   static const _morningAccent = Color(0xFFE8A838);
@@ -50,96 +49,97 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-    _pageController.addListener(_onPageScroll);
-  }
-
-  void _onPageScroll() {
-    if (_pageController.hasClients && _pageController.page != null) {
-      setState(() {
-        _pageValue = _pageController.page!;
-      });
-    }
   }
 
   @override
   void dispose() {
-    _pageController.removeListener(_onPageScroll);
     _pageController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final bgColor = Color.lerp(
-      _morningBg,
-      _nightBg,
-      _pageValue.clamp(0.0, 1.0),
-    )!;
+    // ⚡ Bolt: Use AnimatedBuilder instead of setState in a scroll listener.
+    // This memoizes the complex PageView (passed as `child`) so it isn't rebuilt
+    // 60 times a second during scrolling, improving UI performance.
+    return AnimatedBuilder(
+      animation: _pageController,
+      builder: (context, child) {
+        final pageValue =
+            _pageController.hasClients && _pageController.page != null
+            ? _pageController.page!
+            : 0.0;
 
-    return Theme(
-      data: _pageValue > 0.5
-          ? _nightTheme(context)
-          : _morningTheme(context),
-      child: Scaffold(
-        backgroundColor: bgColor,
-        body: Stack(
-          children: [
-            ScrollConfiguration(
-              behavior: _DesktopDragScrollBehavior(),
-              child: PageView(
-              controller: _pageController,
-              onPageChanged: (index) {
-                setState(() => _currentPage = index);
-                // Reload tasks when swiping back to a page
-                if (index == 0) {
-                  _morningKey.currentState?.reload();
-                } else {
-                  _nightKey.currentState?.reload();
-                }
-              },
+        final bgColor = Color.lerp(
+          _morningBg,
+          _nightBg,
+          pageValue.clamp(0.0, 1.0),
+        )!;
+
+        return Theme(
+          data: pageValue > 0.5 ? _nightTheme(context) : _morningTheme(context),
+          child: Scaffold(
+            backgroundColor: bgColor,
+            body: Stack(
               children: [
-                RoutineScreen(
-                  key: _morningKey,
-                  routineType: 'morning',
-                  storage: widget.storage,
-                  routineRepository: widget.routineRepository,
-                  metricsRepository: widget.metricsRepository,
-                  accentColor: _morningAccent,
-                  backgroundColor: _morningBg,
-                  title: 'Good Morning',
-                  subtitle: 'Start your day right',
-                  icon: Icons.wb_sunny_rounded,
-                ),
-                RoutineScreen(
-                  key: _nightKey,
-                  routineType: 'night',
-                  storage: widget.storage,
-                  routineRepository: widget.routineRepository,
-                  metricsRepository: widget.metricsRepository,
-                  accentColor: _nightAccent,
-                  backgroundColor: _nightBg,
-                  title: 'Good Night',
-                  subtitle: 'Wind down peacefully',
-                  icon: Icons.nightlight_round,
+                child!,
+                // Page indicator
+                Positioned(
+                  bottom: 24,
+                  left: 0,
+                  right: 0,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _buildDot(0, _morningAccent),
+                      const SizedBox(width: 8),
+                      _buildDot(1, _nightAccent),
+                    ],
+                  ),
                 ),
               ],
             ),
+          ),
+        );
+      },
+      child: ScrollConfiguration(
+        behavior: _DesktopDragScrollBehavior(),
+        child: PageView(
+          controller: _pageController,
+          onPageChanged: (index) {
+            setState(() => _currentPage = index);
+            // Reload tasks when swiping back to a page
+            if (index == 0) {
+              _morningKey.currentState?.reload();
+            } else {
+              _nightKey.currentState?.reload();
+            }
+          },
+          children: [
+            RoutineScreen(
+              key: _morningKey,
+              routineType: 'morning',
+              storage: widget.storage,
+              routineRepository: widget.routineRepository,
+              metricsRepository: widget.metricsRepository,
+              accentColor: _morningAccent,
+              backgroundColor: _morningBg,
+              title: 'Good Morning',
+              subtitle: 'Start your day right',
+              icon: Icons.wb_sunny_rounded,
             ),
-            // Page indicator
-            Positioned(
-              bottom: 24,
-              left: 0,
-              right: 0,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  _buildDot(0, _morningAccent),
-                  const SizedBox(width: 8),
-                  _buildDot(1, _nightAccent),
-                ],
-              ),
+            RoutineScreen(
+              key: _nightKey,
+              routineType: 'night',
+              storage: widget.storage,
+              routineRepository: widget.routineRepository,
+              metricsRepository: widget.metricsRepository,
+              accentColor: _nightAccent,
+              backgroundColor: _nightBg,
+              title: 'Good Night',
+              subtitle: 'Wind down peacefully',
+              icon: Icons.nightlight_round,
             ),
-
           ],
         ),
       ),


### PR DESCRIPTION
💡 What: Removed `setState` from the `_pageController` listener and replaced it with an `AnimatedBuilder` that directly manages the scroll animation.
🎯 Why: Calling `setState` inside a scroll listener rebuilds the entire widget tree (including the complex PageView) 60 times a second during a swipe, causing severe CPU overhead and potential UI jank.
📊 Impact: Expected to reduce unnecessary widget rebuilds significantly by memoizing the `PageView` as the static `child` parameter in the `AnimatedBuilder`.
🔬 Measurement: Verify by interacting with the page transition scroll on HomeScreen and using Flutter DevTools' Performance tab to see reduced frame build times.

---
*PR created automatically by Jules for task [374230059938311514](https://jules.google.com/task/374230059938311514) started by @furittsu-desu*